### PR TITLE
Manually apply PR #592 "Have sff_mgr bring a linkup port out of lpmode"

### DIFF
--- a/sonic-xcvrd/xcvrd/sff_mgr.py
+++ b/sonic-xcvrd/xcvrd/sff_mgr.py
@@ -439,7 +439,7 @@ class SffManagerTask(threading.Thread):
                     # Skip if these essential routines are not available
                     continue
                 
-                if xcvr_inserted:
+                if xcvr_inserted or (admin_status_changed and data[self.ADMIN_STATUS] == "up"):
                     set_lp_success = (
                         sfp.set_lpmode(False) 
                         if isinstance(api, Sff8472Api) 


### PR DESCRIPTION
To solve the conflict when cherry-pick the original PR [#592](https://github.com/sonic-net/sonic-platform-daemons/pull/592), manually add the code change. 

 Backport to 202503