### PR TITLE
[PR:618]Add Robust Exception Handling to pcied Daemon for Improved Stability …

### DIFF
--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -53,6 +53,9 @@ def load_platform_pcieutil():
             _platform_pcieutil = PcieUtil(platform_path)
         except ImportError as e:
             log.log_error("Failed to load default PcieUtil module. Error : {}".format(str(e)), True)
+    if _platform_pcieutil is None:
+        log.log_critical("Failed to load any PCIe utility module. Exiting...", True)
+        raise RuntimeError("Unable to load PCIe utility module.")
     return _platform_pcieutil
 
 def read_id_file(device_name):
@@ -89,52 +92,59 @@ class DaemonPcied(daemon_base.DaemonBase):
             sys.exit(PCIEUTIL_LOAD_ERROR)
 
         # Connect to STATE_DB and create pcie device table
-        self.state_db = daemon_base.db_connect("STATE_DB")
-        self.device_table = swsscommon.Table(self.state_db, PCIE_DEVICE_TABLE_NAME)
-        self.status_table = swsscommon.Table(self.state_db, PCIE_STATUS_TABLE_NAME)
+        try:
+            self.state_db = daemon_base.db_connect("STATE_DB")
+            self.device_table = swsscommon.Table(self.state_db, PCIE_DEVICE_TABLE_NAME)
+            self.status_table = swsscommon.Table(self.state_db, PCIE_STATUS_TABLE_NAME)
+        except Exception as e:
+            log.log_critical("Failed to connect to STATE_DB or create table. Error: {}".format(str(e)), True)
+            sys.exit(PCIEUTIL_CONF_FILE_ERROR)
 
     def __del__(self):
-        if self.device_table:
-            table_keys = self.device_table.getKeys()
-            for tk in table_keys:
-                self.device_table._del(tk)
-        if self.status_table:
-            stable_keys = self.status_table.getKeys()
-            for stk in stable_keys:
-                self.status_table._del(stk)
+        try:
+            if self.device_table:
+                table_keys = self.device_table.getKeys()
+                for tk in table_keys:
+                    self.device_table._del(tk)
+            if self.status_table:
+                stable_keys = self.status_table.getKeys()
+                for stk in stable_keys:
+                    self.status_table._del(stk)
+        except Exception as e:
+            log.log_warning("Exception during cleanup: {}".format(str(e)), True)
 
     # load aer-fields into statedb
     def update_aer_to_statedb(self):
         if self.aer_stats is None:
-            self.log_debug("PCIe device {} has no AER Stats".format(device_name))
+            self.log_debug("PCIe device {} has no AER Stats".format(self.device_name))
             return
 
-        aer_fields = {}
-
-        for key, fv in self.aer_stats.items():
-            for field, value in fv.items():
-                key_field = "{}|{}".format(key,field)
-                aer_fields[key_field] = value
-
-        if aer_fields:
-            formatted_fields = swsscommon.FieldValuePairs(list(aer_fields.items()))
-            self.device_table.set(self.device_name, formatted_fields)
-        else:
-            self.log_debug("PCIe device {} has no AER attriutes".format(self.device_name))
+        try:
+            aer_fields = {
+                f"{key}|{field}": value
+                for key, fv in self.aer_stats.items()
+                for field, value in fv.items()
+            }
+            if aer_fields:
+                self.device_table.set(self.device_name, swsscommon.FieldValuePairs(list(aer_fields.items())))
+            else:
+                self.log_debug("PCIe device {} has no AER attributes".format(self.device_name))
+        except Exception as e:
+            self.log_error("Exception while updating AER attributes to STATE_DB for {}: {}".format(self.device_name, str(e)))
 
 
     # Check the PCIe AER Stats
     def check_n_update_pcie_aer_stats(self, Bus, Dev, Fn):
-        self.device_name = "%02x:%02x.%d" % (Bus, Dev, Fn)
-
-        Id = read_id_file(self.device_name)
-
-        self.aer_stats = {}
-        if Id is not None:
-            fvp = swsscommon.FieldValuePairs([('id', Id)])
-            self.device_table.set(self.device_name, fvp)
-            self.aer_stats = platform_pcieutil.get_pcie_aer_stats(bus=Bus, dev=Dev, func=Fn)
-            self.update_aer_to_statedb()
+        try:
+            self.device_name = "%02x:%02x.%d" % (Bus, Dev, Fn)
+            Id = read_id_file(self.device_name)
+            self.aer_stats = {}
+            if Id is not None:
+                self.device_table.set(self.device_name, swsscommon.FieldValuePairs([('id', Id)]))
+                self.aer_stats = platform_pcieutil.get_pcie_aer_stats(bus=Bus, dev=Dev, func=Fn)
+                self.update_aer_to_statedb()
+        except Exception as e:
+            self.log_error("Exception while checking AER attributes for {}: {}".format(self.device_name, str(e)))
 
 
     # Update the PCIe devices status to DB
@@ -145,11 +155,11 @@ class DaemonPcied(daemon_base.DaemonBase):
         else:
             pcie_status = "PASSED"
             self.log_info("PCIe device status check : {}".format(pcie_status))
-        fvs = swsscommon.FieldValuePairs([
-            ('status', pcie_status)
-        ])
 
-        self.status_table.set("status", fvs)
+        try:
+            self.status_table.set("status", swsscommon.FieldValuePairs([('status', pcie_status)]))
+        except Exception as e:
+            self.log_error("Exception while updating PCIe device status to STATE_DB: {}".format(str(e)))
 
     # Check the PCIe devices
     def check_pcie_devices(self):
@@ -190,8 +200,12 @@ class DaemonPcied(daemon_base.DaemonBase):
 
     # Main daemon logic
     def run(self):
-        if self.stop_event.wait(self.timeout):
-            # We received a fatal signal
+        try:
+            if self.stop_event.wait(self.timeout):
+                # We received a fatal signal
+                return False
+        except Exception as e:
+            self.log_error("Exception occurred during stop_event wait: {}".format(str(e)))
             return False
 
         self.check_pcie_devices()

--- a/sonic-pcied/tests/mocked_libs/sonic_platform/pcie.py
+++ b/sonic-pcied/tests/mocked_libs/sonic_platform/pcie.py
@@ -2,7 +2,7 @@
     Mock implementation of sonic_platform package for unit testing
 """
 
-from sonic_platform_base.pcie_base import PcieBase
+from sonic_platform_base.sonic_pcie.pcie_base import PcieBase
 
 
 class Pcie(PcieBase):

--- a/sonic-pcied/tests/test_DaemonPcied.py
+++ b/sonic-pcied/tests/test_DaemonPcied.py
@@ -140,8 +140,55 @@ class TestDaemonPcied(object):
         daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
         daemon_pcied.check_pcie_devices = mock.MagicMock()
 
-        daemon_pcied.run()
-        assert daemon_pcied.check_pcie_devices.call_count == 1
+        # Case 1: Test normal execution path
+        daemon_pcied.stop_event.wait = mock.MagicMock(return_value=False)
+        assert daemon_pcied.run() == True
+        daemon_pcied.check_pcie_devices.assert_called_once()
+
+        # Case 2: Test when stop_event.wait returns True (signal received)
+        daemon_pcied.check_pcie_devices.reset_mock()
+        daemon_pcied.stop_event.wait = mock.MagicMock(return_value=True)
+        assert daemon_pcied.run() == False
+        daemon_pcied.check_pcie_devices.assert_not_called()
+
+        # Case 3: Test exception handling during stop_event.wait
+        daemon_pcied.check_pcie_devices.reset_mock()
+        daemon_pcied.stop_event.wait = mock.MagicMock(side_effect=Exception("Test Exception"))
+        daemon_pcied.log_error = mock.MagicMock()
+        assert daemon_pcied.run() == False
+        daemon_pcied.log_error.assert_called_once_with(
+            "Exception occurred during stop_event wait: Test Exception"
+        )
+        daemon_pcied.check_pcie_devices.assert_not_called()
+
+    @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
+    def test_del(self):
+        daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
+        daemon_pcied.device_table = mock.MagicMock()
+        daemon_pcied.status_table = mock.MagicMock()
+
+        daemon_pcied.device_table.getKeys.return_value = ['device1', 'device2']
+        daemon_pcied.status_table.getKeys.return_value = ['status1']
+
+        daemon_pcied.__del__()
+
+        assert daemon_pcied.device_table._del.call_count == 2
+        daemon_pcied.device_table._del.assert_any_call('device1')
+        daemon_pcied.device_table._del.assert_any_call('device2')
+
+        assert daemon_pcied.status_table._del.call_count == 1
+        daemon_pcied.status_table._del.assert_called_with('status1')
+
+    @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
+    @mock.patch('pcied.log.log_warning')
+    def test_del_exception(self, mock_log_warning):
+        daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
+        daemon_pcied.device_table = mock.MagicMock()
+        daemon_pcied.device_table.getKeys.side_effect = Exception("Test Exception")
+
+        del daemon_pcied
+
+        mock_log_warning.assert_called_once_with("Exception during cleanup: Test Exception", True)
 
     @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
     def test_check_pcie_devices(self):
@@ -160,18 +207,38 @@ class TestDaemonPcied(object):
         daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
         daemon_pcied.log_info = mock.MagicMock()
         daemon_pcied.log_error = mock.MagicMock()
+        daemon_pcied.status_table = mock.MagicMock()
 
-        # test for pass resultInfo
+        # Case 1: test for pass resultInfo
         daemon_pcied.update_pcie_devices_status_db(0)
-        assert daemon_pcied.log_info.call_count == 1
-        assert daemon_pcied.log_error.call_count == 0
+        daemon_pcied.log_info.assert_called_once_with("PCIe device status check : PASSED")
+        daemon_pcied.status_table.set.assert_called_once_with(
+            "status", pcied.swsscommon.FieldValuePairs([('status', 'PASSED')])
+        )
+        daemon_pcied.log_error.assert_not_called()
 
         daemon_pcied.log_info.reset_mock()
+        daemon_pcied.status_table.set.reset_mock()
+        daemon_pcied.log_error.reset_mock()
 
-        # test for resultInfo with 1 device failed to detect
+        # Case 2: test for resultInfo with 1 device failed to detect
         daemon_pcied.update_pcie_devices_status_db(1)
-        assert daemon_pcied.log_info.call_count == 0
-        assert daemon_pcied.log_error.call_count == 1
+        daemon_pcied.log_error.assert_called_once_with("PCIe device status check : FAILED")
+        daemon_pcied.status_table.set.assert_called_once_with(
+            "status", pcied.swsscommon.FieldValuePairs([('status', 'FAILED')])
+        )
+        daemon_pcied.log_info.assert_not_called()
+
+        daemon_pcied.log_info.reset_mock()
+        daemon_pcied.status_table.set.reset_mock()
+        daemon_pcied.log_error.reset_mock()
+
+        # Case 3: test exception handling
+        daemon_pcied.status_table.set.side_effect = Exception("Test Exception")
+        daemon_pcied.update_pcie_devices_status_db(0)
+        daemon_pcied.log_error.assert_called_once_with(
+            "Exception while updating PCIe device status to STATE_DB: Test Exception"
+        )
 
 
     @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
@@ -179,36 +246,82 @@ class TestDaemonPcied(object):
     def test_check_n_update_pcie_aer_stats(self, mock_read):
         daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
         daemon_pcied.update_aer_to_statedb = mock.MagicMock()
+        daemon_pcied.device_table = mock.MagicMock()
+        daemon_pcied.log_error = mock.MagicMock()
         pcied.platform_pcieutil.get_pcie_aer_stats = mock.MagicMock()
 
+        # Case 1: read_id_file returns None, no further actions
         mock_read.return_value = None
-        daemon_pcied.check_n_update_pcie_aer_stats(0,1,0)
-        assert daemon_pcied.update_aer_to_statedb.call_count == 0
-        assert pcied.platform_pcieutil.get_pcie_aer_stats.call_count == 0
+        daemon_pcied.check_n_update_pcie_aer_stats(0, 1, 0)
+        daemon_pcied.device_table.set.assert_not_called()
+        daemon_pcied.update_aer_to_statedb.assert_not_called()
+        pcied.platform_pcieutil.get_pcie_aer_stats.assert_not_called()
+        daemon_pcied.log_error.assert_not_called()
 
+        # Case 2: read_id_file returns valid ID, normal flow
         mock_read.return_value = '1714'
-        daemon_pcied.check_n_update_pcie_aer_stats(0,1,0)
-        assert daemon_pcied.update_aer_to_statedb.call_count == 1
-        assert pcied.platform_pcieutil.get_pcie_aer_stats.call_count == 1
+        pcied.platform_pcieutil.get_pcie_aer_stats.return_value = pcie_aer_stats_no_err
+        daemon_pcied.check_n_update_pcie_aer_stats(0, 1, 0)
+        daemon_pcied.device_table.set.assert_called_once_with(
+            '00:01.0', pcied.swsscommon.FieldValuePairs([('id', '1714')])
+        )
+        daemon_pcied.update_aer_to_statedb.assert_called_once()
+        pcied.platform_pcieutil.get_pcie_aer_stats.assert_called_once_with(bus=0, dev=1, func=0)
+        daemon_pcied.log_error.assert_not_called()
+
+        # Case 3: Exception handling when get_pcie_aer_stats raises exception
+        daemon_pcied.device_table.set.reset_mock()
+        daemon_pcied.update_aer_to_statedb.reset_mock()
+        pcied.platform_pcieutil.get_pcie_aer_stats.side_effect = Exception("Test Exception")
+        daemon_pcied.check_n_update_pcie_aer_stats(0, 1, 0)
+        daemon_pcied.log_error.assert_called_once_with(
+            "Exception while checking AER attributes for 00:01.0: Test Exception"
+        )
 
 
     @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
     def test_update_aer_to_statedb(self):
         daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
         daemon_pcied.log_debug = mock.MagicMock()
-        daemon_pcied.device_name = mock.MagicMock()
+        daemon_pcied.log_error = mock.MagicMock()
+        daemon_pcied.device_table = mock.MagicMock()
+        daemon_pcied.device_name = "PCIe Device 1"
+
+        # Case 1: Test when aer_stats is None
+        daemon_pcied.aer_stats = None
+        daemon_pcied.update_aer_to_statedb()
+        daemon_pcied.log_debug.assert_called_once_with("PCIe device PCIe Device 1 has no AER Stats")
+        daemon_pcied.device_table.set.assert_not_called()
+        daemon_pcied.log_debug.reset_mock()
+
+        # Case 2: Test when aer_stats is empty
+        daemon_pcied.aer_stats = {'correctable': {}, 'fatal': {}, 'non_fatal': {}}
+        daemon_pcied.update_aer_to_statedb()
+        daemon_pcied.log_debug.assert_called_once_with("PCIe device PCIe Device 1 has no AER attributes")
+        daemon_pcied.device_table.set.assert_not_called()
+        daemon_pcied.log_debug.reset_mock()
+
+        # Case 3: Test when aer_stats has valid data
         daemon_pcied.aer_stats = pcie_aer_stats_no_err
+        daemon_pcied.update_aer_to_statedb()
+        expected_fields = [
+            ("correctable|field1", '0'),
+            ("correctable|field2", '0'),
+            ("fatal|field3", '0'),
+            ("fatal|field4", '0'),
+            ("non_fatal|field5", '0'),
+            ("non_fatal|field6", '0'),
+        ]
+        daemon_pcied.device_table.set.assert_called_once_with(
+            "PCIe Device 1",
+            pcied.swsscommon.FieldValuePairs(expected_fields)
+        )
+        daemon_pcied.log_debug.assert_not_called()
+        daemon_pcied.device_table.set.reset_mock()
 
-        """
-        mocked_expected_fvp = pcied.swsscommon.FieldValuePairs(
-            [("correctable|field1", '0'),
-             ("correctable|field2", '0'),
-             ("fatal|field3", '0'),
-             ("fatal|field4", '0'),
-             ("non_fatal|field5", '0'),
-             ("non_fatal|field6", '0'),
-             ])
-        """
-
-        daemon_pcied.update_aer_to_statedb() 
-        assert daemon_pcied.log_debug.call_count == 0
+        # Case 4: Test exception handling
+        daemon_pcied.device_table.set.side_effect = Exception("Test Exception")
+        daemon_pcied.update_aer_to_statedb()
+        daemon_pcied.log_error.assert_called_once_with(
+            "Exception while updating AER attributes to STATE_DB for PCIe Device 1: Test Exception"
+        )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
This PR introduces comprehensive exception handling throughout the pcied daemon script to enhance reliability and ensure graceful handling of runtime errors. Key improvements include:

- Try-except blocks added around critical operations
- Fix variables during logging.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
These changes make the daemon more resilient during unexpected conditions for REDIS DB disconnection or returning an exception.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
- Replace the daemon in a test-bed
- Inject redis-server crash
- Observe any crashes occurred for PCIe daemon.

- With the changes, only observe following exception but no crashes in PCIe daemon:


2025 Jun 10 22:26:51.529324 XXX ERR pmon#pcied[4197]: Exception while checking AER attributes for ff:13.2: RedisError: Failed to redisGetReply in RedisPipeline::pop, err=3: errstr=Server closed the connection
2025 Jun 10 22:26:51.536091 XXX ERR pmon#pcied[4197]: Exception while checking AER attributes for ff:1f.0: RedisError: Failed to redisGetReply in RedisPipeline::pop, err=3: errstr=Server closed the connection
2025 Jun 10 22:26:51.536280 XXX ERR pmon#pcied[4197]: Exception while checking AER attributes for ff:1f.2: RedisError: Failed to redisGetReply in RedisPipeline::pop, err=3: errstr=Server closed the connection
2025 Jun 10 22:26:51.536471 XXX ERR pmon#pcied[4197]: Exception while updating PCIe device status to STATE_DB: RedisError: Failed to redisGetReply in RedisPipeline::pop, err=3: errstr=Server closed the connection


#### Additional Information (Optional)
