### PR TITLE
[xcvrd] silence port update event warnings (#567)

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/port_event_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/port_event_helper.py
@@ -102,8 +102,8 @@ class PortChangeObserver:
                 port_tbl.filter = d['FILTER'] if 'FILTER' in d else None
                 asic_context[port_tbl] = asic_id
                 sel.addSelectable(port_tbl)
-                self.logger.log_warning("subscribing to port_tbl {} - {} DB of namespace {} ".format(
-                                            port_tbl, list(d.values())[0], namespace))
+                self.logger.log_info("subscribing to port_tbl {} - {} DB of namespace {} ".format(
+                                     port_tbl, list(d.values())[0], namespace))
         self.sel, self.asic_context = sel, asic_context
 
     def handle_port_update_event(self):
@@ -144,8 +144,8 @@ class PortChangeObserver:
                     if not multi_asic.is_front_panel_port(port_name, role):
                         continue
 
-                    self.logger.log_warning("$$$ {} handle_port_update_event() : op={} DB:{} Table:{} fvp {}".format(
-                                                            port_name, op, port_tbl.db_name, port_tbl.table_name, fvp))
+                    self.logger.log_info("$$$ {} handle_port_update_event() : op={} DB:{} Table:{} fvp {}".format(
+                                         port_name, op, port_tbl.db_name, port_tbl.table_name, fvp))
                     if 'index' not in fvp:
                        fvp['index'] = '-1'
                     fvp['port_name'] = port_name
@@ -193,7 +193,7 @@ class PortChangeObserver:
                                                             db_name,
                                                             table_name)
                 # This is the final event considered for processing
-                self.logger.log_warning("*** {} handle_port_update_event() fvp {}".format(
+                self.logger.log_notice("*** {} handle_port_update_event() fvp {}".format(
                     key, fvp))
                 if port_change_event is not None:
                     has_event = True


### PR DESCRIPTION
* [xcvrd] silence port update event warnings

Warnings should only be used to alert an administrator that something could cause issues.  Typically warnings will be evaluated by an administrator as tagged by their SIEM, so it makes sense to reduce the workload by not incorrectly tagging these log messages.

Reduced the log level to NOTICE which will still appear at the default log levels in case anyone is parsing these events in their SIEM.

Signed-off-by: Brad House (@bradh352)
(cherry picked from commit ea8715f2134548f34ba71e4b20a96e09bf52a6e8)

This PR requires the PR:  https://github.com/sonic-net/sonic-platform-daemons/pull/630