### PR TITLE
[xcvrd] Improve logging in case of unable to find appropriate match for optic SI settings

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
@@ -65,7 +65,9 @@ def get_optics_si_settings_value(physical_port, lane_speed, key, vendor_name_str
             if len(default_dict) != 0:
                 return default_dict
             else:
-                helper_logger.log_error("Error: No values for physical port '{}'".format(physical_port))
+                helper_logger.log_info("No values for physical port '{}' lane speed '{}' "
+                                       "key '{}' vendor '{}'".format(
+                                       physical_port, lane_speed, key, vendor_name_str))
             return {}
 
         key_dict = {}


### PR DESCRIPTION
Cherry-pick of PR672: https://github.com/sonic-net/sonic-platform-daemons/pull/672
This pull request makes a minor change to the logging behavior in the `get_optics_si_settings_value` function. Instead of logging an error when no values are found for a physical port, it now logs this situation as informational, including more context in the log message.

* Logging change: Updated the message from an error to an info log, with additional details about `physical_port`, `lane_speed`, `key`, and `vendor_name_str` in `sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py`.