### PR TITLE
[202412] Re-arm timer for CMIS Datapath pre-init check (#707)

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1151,10 +1151,15 @@ class CmisManagerTask(threading.Thread):
                                api.tx_disable_channel(media_lanes_mask, True)
                                self.port_dict[lport]['forced_tx_disabled'] = True
                                txoff_duration = self.get_cmis_dp_tx_turnoff_duration_secs(api)
+                               self.port_dict[lport]['txoff_duration'] = txoff_duration
                                self.log_notice("{}: Tx turn off duration {} secs".format(lport, txoff_duration))
-                               self.update_cmis_state_expiration_time(lport, txoff_duration)
                            self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
                            continue
+
+                        # Arm timer for CMIS_STATE_DP_PRE_INIT_CHECK state
+                        if self.port_dict[lport].get('forced_tx_disabled', False):
+                            txoff_duration = self.port_dict[lport].get('txoff_duration', 0)
+                            self.update_cmis_state_expiration_time(lport, txoff_duration)
                         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_PRE_INIT_CHECK)
                     if state == CMIS_STATE_DP_PRE_INIT_CHECK:
                         if self.port_dict[lport].get('forced_tx_disabled', False):


### PR DESCRIPTION
Cherry-pick for https://github.com/sonic-net/sonic-platform-daemons/pull/707

**Description**
Re-arm the timer before entering CMIS Datapath pre-init check

**Motivation and Context**
There could be a module which may take more time to transition its Datapath to DPinitialized or Deactivated state when the TX is turned OFF. The retry code today will not set the timer again after the DP state is transitioning through DPInit and sometime can be stuck there (bad module).

By re-arming the timer before entering the CMIS_STATE_DP_PRE_INIT_CHECK ensures the state machine will timeout appropriately

**How Has This Been Tested?**
xcvrd remains stable post restart
Manually modified the DP state to be not DataPathDeactivated or DataPathInitialized and ensured that the CMIS SM eventually transitions to FAILED state post 4 retries post issuing interface shutdown followed by no shutdown.
Ensure link comes up post shut/no shut

Additional Information (Optional)
MSFT ADO - 35916818