### PR TITLE
Fix indentation error of _get_sfp_temperature_from_db function

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -825,7 +825,7 @@ class TemperatureUpdater(logger.Logger):
             except Exception:
                 pass
 
-        def _get_sfp_temperature_from_db(self, port_name):
+    def _get_sfp_temperature_from_db(self, port_name):
         """
         Get SFP temperature from Redis. First tries TRANSCEIVER_DOM_TEMPERATURE table,
         then falls back to TRANSCEIVER_DOM_SENSOR table. Both are populated by xcvrd daemon.


### PR DESCRIPTION
Fix indentation error introduced by https://github.com/Azure/sonic-platform-daemons.msft/pull/60