### PR TITLE
Fix build error

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -688,8 +688,6 @@ class ChassisdDaemon(daemon_base.DaemonBase):
 
             self.log_info("Stop daemon main loop")
 
-            if config_manager is not None:
-                config_manager.task_stop()
         finally:
             # If we don't cleanup the config_manager process the chassisd process
             # won't die when an exception occurs.


### PR DESCRIPTION
https://github.com/Azure/sonic-platform-daemons.msft/pull/62/changes caused the below errors

```
    
    
        if ((self.module_updater.my_slot == INVALID_SLOT) or
                (self.module_updater.supervisor_slot == INVALID_SLOT)):
            self.log_error("Chassisd not supported for this platform")
            sys.exit(CHASSIS_NOT_SUPPORTED)
    
        try:
            # Start configuration manager task on supervisor module
            if self.module_updater.supervisor_slot == self.module_updater.my_slot:
                self.config_manager = ConfigManagerTask()
                self.config_manager.task_run()
            else:
                self.config_manager = None
    
            # Start main loop
            self.log_info("Start daemon main loop")
    
            while not self.stop.wait(self.loop_interval):
                self.module_updater.module_db_update()
                self.module_updater.check_midplane_reachability()
                self.module_updater.module_down_chassis_db_cleanup()
    
            self.log_info("Stop daemon main loop")
    
>           if config_manager is not None:
E           NameError: name 'config_manager' is not defined


```