### PR TITLE
[xcvrd][tests] Fix test_sfp_removal_from_dict for 202405 branch

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3396,24 +3396,27 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_change_event')
     @patch('xcvrd.xcvrd.del_port_sfp_dom_info_from_db')
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.notify_media_setting')
-    @patch('xcvrd.dom.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db')
+    @patch('xcvrd.dom_mgr.DomInfoUpdateTask.post_port_sfp_firmware_info_to_db')
+    @patch('xcvrd.xcvrd.post_port_dom_threshold_info_to_db')
     @patch('xcvrd.xcvrd.post_port_sfp_info_to_db')
     @patch('xcvrd.xcvrd.update_port_transceiver_status_table_sw')
-    @patch('xcvrd.xcvrd.platform_chassis')
-    def test_sfp_removal_from_dict(self, mock_platform_chassis, mock_update_status, mock_post_sfp_info,
-                                            mock_post_firmware_info, mock_update_media_setting,
+    @patch('xcvrd.xcvrd.delete_port_from_status_table_hw')
+    # NOTE: create=True because earlier tests (test_DaemonXcvrd_init_deinit_*) invoke
+    # DaemonXcvrd.deinit() which removes `platform_chassis` from xcvrd.xcvrd globals via
+    # `del globals()['platform_chassis']`. Without create=True, patching this attribute
+    # raises AttributeError when this test runs after those tests.
+    @patch('xcvrd.xcvrd.platform_chassis', create=True)
+    def test_sfp_removal_from_dict(self, mock_platform_chassis, mock_del_status_hw, mock_update_status, mock_post_sfp_info,
+                                            mock_post_dom_th, mock_post_firmware_info, mock_update_media_setting,
                                             mock_del_dom, mock_change_event, mock_mapping_event, mock_os_kill):
         port_mapping = PortMapping()
         mock_sfp = MagicMock()
         mock_sfp.remove_xcvr_api = MagicMock(return_value=None)
         mock_platform_chassis.get_sfp.return_value = mock_sfp
-        mock_sfp_obj_dict = MagicMock()
         stop_event = threading.Event()
         sfp_error_event = threading.Event()
-        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, mock_sfp_obj_dict, stop_event, sfp_error_event)
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
-        task.dom_db_utils.post_port_dom_thresholds_to_db = MagicMock()
-        task.vdm_db_utils.post_port_vdm_thresholds_to_db = MagicMock()
         mock_change_event.return_value = (True, {0: 0}, {})
         mock_mapping_event.return_value = SYSTEM_NOT_READY
 
@@ -3458,8 +3461,7 @@ class TestXcvrdScript(object):
         task.task_worker(stop_event, sfp_error_event)
         assert mock_update_status.call_count == 1
         assert mock_post_sfp_info.call_count == 2  # first call and retry call
-        assert task.dom_db_utils.post_port_dom_thresholds_to_db.call_count == 0
-        assert task.vdm_db_utils.post_port_vdm_thresholds_to_db.call_count == 0
+        assert mock_post_dom_th.call_count == 0
         assert mock_post_firmware_info.call_count == 0
         assert mock_update_media_setting.call_count == 0
         assert 'Ethernet0' in task.retry_eeprom_set
@@ -3473,8 +3475,7 @@ class TestXcvrdScript(object):
         task.task_worker(stop_event, sfp_error_event)
         assert mock_update_status.call_count == 1
         assert mock_post_sfp_info.call_count == 1
-        assert task.dom_db_utils.post_port_dom_thresholds_to_db.call_count == 1
-        assert task.vdm_db_utils.post_port_vdm_thresholds_to_db.call_count == 1
+        assert mock_post_dom_th.call_count == 1
         assert mock_post_firmware_info.call_count == 0
         assert mock_update_media_setting.call_count == 1
 


### PR DESCRIPTION
## Summary

Fixes the build failure introduced by the cherry-pick of PR #68 (commit `45413d4`, "xcvrd: Remove SFP API object when SFP is removed"):

```
tests/test_xcvrd.py::TestXcvrdScript::test_sfp_removal_from_dict FAILED
E   AttributeError: <module 'xcvrd.xcvrd'> does not have the attribute 'platform_chassis'
```

## Why this surfaces on 202405 but not on master

`DaemonXcvrd.deinit()` ends with:

```python
del globals()['platform_chassis']
```

`test_DaemonXcvrd_init_deinit_cold` (on both branches) calls `deinit()`, which permanently removes `platform_chassis` from the `xcvrd.xcvrd` module within the pytest process. Any later test that does `@patch('xcvrd.xcvrd.platform_chassis')` then fails at patch-entry time.

**The critical difference**: on master, the very next test, `test_DaemonXcvrd_signal_handler`, opens with:

```python
def test_DaemonXcvrd_signal_handler(self):
    xcvrd.platform_chassis = MagicMock()
```

That assignment re-creates the module attribute, masking the `deinit()` side-effect for every test that runs after it (including `test_sfp_removal_from_dict`). The 202405 branch does not have `test_DaemonXcvrd_signal_handler` (nor any other test that re-sets `xcvrd.platform_chassis` after `deinit_cold`), so the attribute stays deleted for the remainder of the run and the new `test_sfp_removal_from_dict` is the first `@patch('xcvrd.xcvrd.platform_chassis')` to hit the gap.

In other words: master accidentally hides the latent test-pollution bug; 202405 doesn't.

## What's in this PR

The test was authored against master's much more refactored `SfpStateUpdateTask`. Adjustments to match 202405's actual shape:

| Issue | Fix |
|---|---|
| `AttributeError` due to prior `deinit()` deleting the global, with nothing to restore it on 202405 | `create=True` on the `platform_chassis` patch (defensive) |
| `@patch('xcvrd.dom.dom_mgr...')` — no `xcvrd/dom/` package on 202405 (only `xcvrd/dom_mgr.py`) | `@patch('xcvrd.dom_mgr...')` |
| 5-arg `SfpStateUpdateTask(..., sfp_obj_dict, ...)` ctor doesn't exist on 202405 | Use the 4-arg 202405 ctor |
| `task.dom_db_utils` / `task.vdm_db_utils` not present on 202405; insert path calls module-level `post_port_dom_threshold_info_to_db` instead | Patch that, replace the corresponding assertions |
| 202405 SFP-remove branch additionally calls `delete_port_from_status_table_hw`, which master no longer does — caused `ValueError: not enough values to unpack (expected 2, got 0)` inside `status_tbl.get()` | Add `@patch('xcvrd.xcvrd.delete_port_from_status_table_hw')` |

No production code changes. The core behavior assertion from PR #68 — `mock_sfp.remove_xcvr_api.assert_called_once()` — is preserved.

## Test

```
tests/test_xcvrd.py::TestXcvrdScript::test_sfp_removal_from_dict PASSED
```
